### PR TITLE
update for recent AFC API version and current default config; add tool mapping (Tx) and lane mapping for commands sent to AFC API

### DIFF
--- a/src/api_fetch.cpp
+++ b/src/api_fetch.cpp
@@ -2,10 +2,11 @@
 
 String apiURL;
 float eventTime;
-bool leg1Load;
-bool leg2Load;
-bool leg3Load;
-bool leg4Load;
+
+bool legLoad[NUM_LEGS];
+int  legLane[NUM_LEGS];
+int  legMapTool[NUM_LEGS];
+
 const char *currentLoad;
 bool toolLoaded;
 bool loadedToHub;
@@ -81,7 +82,7 @@ void ParseAPIResponse(const String &jsonResponse) {
 
     eventTime = result["eventtime"].as<float>();
 
-    JsonObject status = result["status"];
+    JsonObject status = result["status:"];
     JsonObject afc = status["AFC"];
     JsonObject turtleUnit;
     String turtleUnitName;
@@ -94,9 +95,11 @@ void ParseAPIResponse(const String &jsonResponse) {
     if (!turtleUnit.isNull()) {
         DEBUG_PRINT(turtleUnitName + " Object: ");
         // Iterate through the legs (leg1, leg2, leg3, leg4)
-        for (int leg = 1; leg <= 4; ++leg) {
-            String legKey = "leg" + String(leg);
-            if (turtleUnit.containsKey(legKey)) {
+        for (int n = 0; n <= 3; ++n)  // try to find 4 lane keys from 'lane1' to 'lane4' - TODO: extend number of keys to find to 12
+        {
+            String legKey = "lane" + String(n+1);
+            if (turtleUnit.containsKey(legKey)) 
+            {
                 JsonObject legData = turtleUnit[legKey];
                 bool load = legData["load"];
                 bool prep = legData["prep"];
@@ -105,9 +108,16 @@ void ParseAPIResponse(const String &jsonResponse) {
                 String spool_id = legData["spool_id"].as<String>();
                 String color = legData["color"].as<String>();
                 float weight = legData["weight"].as<float>();
+                int lane = legData["lane"];
+                String smap = legData["map"].as<String>();
+                if((smap[0] == 'T') && (smap.length() == 2))
+                    legMapTool[n] = (int)(smap[1] - '0');
+                else
+                    legMapTool[n] = -1; // TODO: error handling for missing mapping lane -> tool
+                
+                legLane[n] = lane;
 
-                int lane = legData["LANE"];
-                DEBUG_PRINT("Lane ");
+                DEBUG_PRINT("lane ");
                 DEBUG_PRINT(lane);
                 DEBUG_PRINT(" - Load: ");
                 DEBUG_PRINT(load ? "true" : "false");
@@ -123,23 +133,8 @@ void ParseAPIResponse(const String &jsonResponse) {
                 DEBUG_PRINT(color);
                 DEBUG_PRINT(", Weight: ");
                 DEBUG_PRINTLN(weight);
-                // Update leg load statuses
-                switch (lane) {
-                    case 1:
-                        leg1Load = load;
-                        break;
-                    case 2:
-                        leg2Load = load;
-                        break;
-                    case 3:
-                        leg3Load = load;
-                        break;
-                    case 4:
-                        leg4Load = load;
-                        break;
-                    default:
-                        break;
-                }
+                // Update leg/lane load statuses
+                legLoad[n] = load;
             } else {
                 DEBUG_PRINT("Checking key: ");
                 DEBUG_PRINTLN(legKey);
@@ -201,13 +196,13 @@ void ParseAPIResponse(const String &jsonResponse) {
         DEBUG_PRINTLN("System key not found in AFC.");
     }
     DEBUG_PRINT("Lane 1 Status: ");
-    DEBUG_PRINTLN(leg1Load);
+    DEBUG_PRINTLN(legLoad[0]);
     DEBUG_PRINT("Lane 2 Status: ");
-    DEBUG_PRINTLN(leg2Load);
+    DEBUG_PRINTLN(legLoad[1]);
     DEBUG_PRINT("Lane 3 Status: ");
-    DEBUG_PRINTLN(leg3Load);
+    DEBUG_PRINTLN(legLoad[2]);
     DEBUG_PRINT("Lane 4 Status: ");
-    DEBUG_PRINTLN(leg4Load);
+    DEBUG_PRINTLN(legLoad[3]);
     DEBUG_PRINT("Tool Status: ");
     DEBUG_PRINTLN(toolLoaded ? "true" : "false");
     DEBUG_PRINT("Current Load: ");

--- a/src/api_fetch.h
+++ b/src/api_fetch.h
@@ -8,10 +8,12 @@
 #include "debug.hpp"
 
 extern float eventTime;
-extern bool leg1Load;
-extern bool leg2Load;
-extern bool leg3Load;
-extern bool leg4Load;
+
+#define NUM_LEGS    12   // TODO: support dynamic number of legs/lanes
+extern bool legLoad[NUM_LEGS];
+extern int  legLane[NUM_LEGS];
+extern int  legMapTool[NUM_LEGS];
+
 extern const char* currentLoad;
 extern char currentLoadBuffer[32];
 extern bool toolLoaded;

--- a/src/lvgl_usr.cpp
+++ b/src/lvgl_usr.cpp
@@ -34,7 +34,10 @@ uint32_t lv_color_to_hex(lv_color_t color) {
 }
 
 void lvgl_set_current_leg() {
-   if (currentLoadBuffer != nullptr)activeLane = atoi(&currentLoadBuffer[3]);
+   if (strlen(currentLoadBuffer) == 5) 
+        activeLane = atoi(&currentLoadBuffer[4]);
+   else 
+        activeLane = -1;
 }
 
 void lvgl_set_tool_status(){
@@ -71,14 +74,11 @@ void lvgl_set_active_lane_color(){
 }
 
 void lvgl_set_leg_status(){
-    if(leg1Load){lv_obj_set_style_bg_color(ui_Tool0Button, loadedColor, LV_PART_MAIN);}
-    else{lv_obj_set_style_bg_color(ui_Tool0Button, unloadedColor, LV_PART_MAIN);}
-    if(leg2Load){lv_obj_set_style_bg_color(ui_Tool1Button, loadedColor, LV_PART_MAIN);}
-    else{lv_obj_set_style_bg_color(ui_Tool1Button, unloadedColor, LV_PART_MAIN);}
-    if(leg3Load){lv_obj_set_style_bg_color(ui_Tool2Button, loadedColor, LV_PART_MAIN);}
-    else{lv_obj_set_style_bg_color(ui_Tool2Button, unloadedColor, LV_PART_MAIN);}
-    if(leg4Load){lv_obj_set_style_bg_color(ui_Tool3Button, loadedColor, LV_PART_MAIN);}
-    else{lv_obj_set_style_bg_color(ui_Tool3Button, unloadedColor, LV_PART_MAIN);}
+    assert(NUM_LEGS == 4);  // TODO: support dynamic number of legs/lanes
+    lv_obj_set_style_bg_color(ui_Tool0Button, legLoad[0] ? loadedColor : unloadedColor, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(ui_Tool1Button, legLoad[1] ? loadedColor : unloadedColor, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(ui_Tool2Button, legLoad[2] ? loadedColor : unloadedColor, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(ui_Tool3Button, legLoad[3] ? loadedColor : unloadedColor, LV_PART_MAIN);
     lvgl_set_active_lane_color();
 }
 

--- a/src/moonraker.cpp
+++ b/src/moonraker.cpp
@@ -156,12 +156,8 @@ void MOONRAKER::get_printer_info(void) {
             data.pause = json_parse["state"]["flags"]["pausing"].as<bool>() ||
                          json_parse["state"]["flags"]["paused"].as<bool>();
             data.printing = json_parse["state"]["flags"]["printing"].as<bool>() ||
-                            json_parse["state"]["flags"]["cancelling"].as<bool>() || data.pause;
-            data.pause = json_parse["state"]["flags"]["pausing"].as<bool>();
-            data.pause |= json_parse["state"]["flags"]["paused"].as<bool>();
-            data.printing = json_parse["state"]["flags"]["printing"].as<bool>(); 
-            data.printing |= json_parse["state"]["flags"]["cancelling"].as<bool>();
-            data.printing |= data.pause;
+                            json_parse["state"]["flags"]["cancelling"].as<bool>() || 
+                            data.pause;
             data.bed_actual = int16_t(json_parse["temperature"]["bed"]["actual"].as<double>() + 0.5f);
             data.bed_target = int16_t(json_parse["temperature"]["bed"]["target"].as<double>() + 0.5f);
             data.nozzle_actual = int16_t(json_parse["temperature"]["tool0"]["actual"].as<double>() + 0.5f);
@@ -238,6 +234,10 @@ void MOONRAKER::get_progress(void)
 
 void MOONRAKER::get_AFC_status(void)
 {
+    #if 1
+        return;   // _AFC_Status is no longer a gcode_macro, so polling this does not make any sense any longer
+    #endif
+    
     http.begin("http://" + targetHost + "/printer/objects/query?gcode_macro%20_AFC_STATUS");
     int httpresponsecode = http.GET();
     if (httpresponsecode > 0)

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -6,6 +6,9 @@
 #include "ui.h"
 #include "ui_helpers.h"
 
+extern int legLane[12];
+extern int legMapTool[12];
+
 ///////////////////// VARIABLES ////////////////////
 void GifPop_Animation(lv_obj_t * TargetObject, int delay);
 
@@ -229,7 +232,7 @@ void ui_event_Tool0Button(lv_event_t * e)
     lv_event_code_t event_code = lv_event_get_code(e);
 
     if(event_code == LV_EVENT_CLICKED) {
-        selectedTool = 0;
+        selected = 0;
         _ui_screen_change(&ui_CurrentLaneToggle, LV_SCR_LOAD_ANIM_FADE_ON, 500, 0, &ui_CurrentLaneToggle_screen_init);
     }
 }
@@ -239,7 +242,7 @@ void ui_event_Tool1Button(lv_event_t * e)
     lv_event_code_t event_code = lv_event_get_code(e);
 
     if(event_code == LV_EVENT_CLICKED) {
-        selectedTool = 1;
+        selected = 1;
         _ui_screen_change(&ui_CurrentLaneToggle, LV_SCR_LOAD_ANIM_FADE_ON, 500, 0, &ui_CurrentLaneToggle_screen_init);
     }
 }
@@ -249,7 +252,7 @@ void ui_event_Tool2Button(lv_event_t * e)
     lv_event_code_t event_code = lv_event_get_code(e);
 
     if(event_code == LV_EVENT_CLICKED) {
-        selectedTool = 2;
+        selected = 2;
         _ui_screen_change(&ui_CurrentLaneToggle, LV_SCR_LOAD_ANIM_FADE_ON, 500, 0, &ui_CurrentLaneToggle_screen_init);
     }
 }
@@ -259,7 +262,7 @@ void ui_event_Tool3Button(lv_event_t * e)
     lv_event_code_t event_code = lv_event_get_code(e);
 
     if(event_code == LV_EVENT_CLICKED) {
-        selectedTool = 3;
+        selected = 3;
         _ui_screen_change(&ui_CurrentLaneToggle, LV_SCR_LOAD_ANIM_FADE_ON, 500, 0, &ui_CurrentLaneToggle_screen_init);
     }
 }
@@ -269,7 +272,7 @@ void ui_event_Tool4Button(lv_event_t * e)
     lv_event_code_t event_code = lv_event_get_code(e);
 
     if(event_code == LV_EVENT_CLICKED) {
-        selectedTool = 4;
+        selected = 4;
         _ui_screen_change(&ui_CurrentLaneToggle, LV_SCR_LOAD_ANIM_FADE_ON, 500, 0, &ui_CurrentLaneToggle_screen_init);
     }
 }
@@ -279,7 +282,7 @@ void ui_event_Tool5Button(lv_event_t * e)
     lv_event_code_t event_code = lv_event_get_code(e);
 
     if(event_code == LV_EVENT_CLICKED) {
-        selectedTool = 5;
+        selected = 5;
         _ui_screen_change(&ui_CurrentLaneToggle, LV_SCR_LOAD_ANIM_FADE_ON, 500, 0, &ui_CurrentLaneToggle_screen_init);
     }
 }
@@ -289,7 +292,7 @@ void ui_event_Tool6Button(lv_event_t * e)
     lv_event_code_t event_code = lv_event_get_code(e);
 
     if(event_code == LV_EVENT_CLICKED) {
-        selectedTool = 6;
+        selected = 6;
         _ui_screen_change(&ui_CurrentLaneToggle, LV_SCR_LOAD_ANIM_FADE_ON, 500, 0, &ui_CurrentLaneToggle_screen_init);
     }
 }
@@ -299,7 +302,7 @@ void ui_event_Tool7Button(lv_event_t * e)
     lv_event_code_t event_code = lv_event_get_code(e);
 
     if(event_code == LV_EVENT_CLICKED) {
-        selectedTool = 7;
+        selected = 7;
         _ui_screen_change(&ui_CurrentLaneToggle, LV_SCR_LOAD_ANIM_FADE_ON, 500, 0, &ui_CurrentLaneToggle_screen_init);
     }
 }
@@ -309,7 +312,7 @@ void ui_event_Tool8Button(lv_event_t * e)
     lv_event_code_t event_code = lv_event_get_code(e);
 
     if(event_code == LV_EVENT_CLICKED) {
-        selectedTool = 8;
+        selected = 8;
         _ui_screen_change(&ui_CurrentLaneToggle, LV_SCR_LOAD_ANIM_FADE_ON, 500, 0, &ui_CurrentLaneToggle_screen_init);
     }
 }
@@ -319,7 +322,7 @@ void ui_event_Tool9Button(lv_event_t * e)
     lv_event_code_t event_code = lv_event_get_code(e);
 
     if(event_code == LV_EVENT_CLICKED) {
-        selectedTool = 9;
+        selected = 9;
         _ui_screen_change(&ui_CurrentLaneToggle, LV_SCR_LOAD_ANIM_FADE_ON, 500, 0, &ui_CurrentLaneToggle_screen_init);
     }
 }
@@ -329,7 +332,7 @@ void ui_event_Tool10Button(lv_event_t * e)
     lv_event_code_t event_code = lv_event_get_code(e);
 
     if(event_code == LV_EVENT_CLICKED) {
-        selectedTool = 10;
+        selected = 10;
         _ui_screen_change(&ui_CurrentLaneToggle, LV_SCR_LOAD_ANIM_FADE_ON, 500, 0, &ui_CurrentLaneToggle_screen_init);
     }
 }
@@ -339,7 +342,7 @@ void ui_event_Tool11Button(lv_event_t * e)
     lv_event_code_t event_code = lv_event_get_code(e);
 
     if(event_code == LV_EVENT_CLICKED) {
-        selectedTool = 11;
+        selected = 11;
         _ui_screen_change(&ui_CurrentLaneToggle, LV_SCR_LOAD_ANIM_FADE_ON, 500, 0, &ui_CurrentLaneToggle_screen_init);
     }
 }
@@ -367,7 +370,8 @@ void ui_event_ActivateLane(lv_event_t * e)
     lv_event_code_t event_code = lv_event_get_code(e);
 
     if(event_code == LV_EVENT_CLICKED) {
-        SetLaneActive(e, selectedTool);
+        SetToolActive(e, legMapTool[selected]);
+        _ui_screen_change(&ui_LaneSelect, LV_SCR_LOAD_ANIM_FADE_ON, 500, 0, &ui_LaneSelect_screen_init);  // after action switch back to main screen
     }
 }
 
@@ -376,7 +380,8 @@ void ui_event_EjectLane(lv_event_t * e)
     lv_event_code_t event_code = lv_event_get_code(e);
 
     if(event_code == LV_EVENT_CLICKED) {
-        EjectLane(e, selectedTool);
+        EjectLane(e, legLane[selected]);
+        _ui_screen_change(&ui_LaneSelect, LV_SCR_LOAD_ANIM_FADE_ON, 500, 0, &ui_LaneSelect_screen_init);  // after action switch back to main screen
     }
 }
 
@@ -386,7 +391,7 @@ void ui_event_BackLaneToggle(lv_event_t * e)
 
     if(event_code == LV_EVENT_CLICKED) {
         _ui_screen_change(&ui_LaneSelect, LV_SCR_LOAD_ANIM_FADE_ON, 500, 0, &ui_LaneSelect_screen_init);
-        selectedTool = -1;
+        selected = -1;
     }
 }
 

--- a/src/ui_functions.cpp
+++ b/src/ui_functions.cpp
@@ -5,7 +5,7 @@ lv_obj_t *gif_img;
 lv_color_t color;
 
 int colorChangeState = -1;
-int selectedTool = -1;
+int selected = -1;
 
 void toolChangeCall(lv_event_t * e, int toolNo){
     char command[10];
@@ -75,15 +75,15 @@ void saveColorWheel(lv_event_t * e){
     color = lv_colorwheel_get_rgb(ui_Colorwheel1);
 }
 
-void SetLaneActive(lv_event_t * e, int laneActive){
+void SetToolActive(lv_event_t * e, int tool){
     char command[10];
-    snprintf(command, sizeof(command), "t%d", laneActive);
+    snprintf(command, sizeof(command), "T%d", tool);
     moonraker.post_gcode_to_queue(command);
 }
 
-void EjectLane(lv_event_t * e, int laneEject){
-    char command[20];
-    snprintf(command, sizeof(command), "BT_LANE_EJECT LANE=%d", laneEject);
+void EjectLane(lv_event_t * e, int lane){
+    char command[40];  // buffer length of 20 was too short for BT_LANE_EJECT LANE=%d
+    snprintf(command, sizeof(command), "BT_LANE_EJECT LANE=%d", lane);
     moonraker.post_gcode_to_queue(command);
     
 }

--- a/src/ui_functions.h
+++ b/src/ui_functions.h
@@ -10,7 +10,7 @@ extern "C" {
 
 extern lv_color_t color;
 extern int colorChangeState;
-extern int selectedTool;
+extern int selected;
 
 void toolChangeCall(lv_event_t * e, int toolNo);
 void ejectLaneCall(lv_event_t * e, int toolNo);
@@ -27,8 +27,8 @@ void setUnloadedColor(lv_event_t * e);
 void setButtonColor(lv_event_t * e);
 void saveColorWheel(lv_event_t * e);
 
-void SetLaneActive(lv_event_t * e, int activeLane);
-void EjectLane(lv_event_t * e, int ejectLane);
+void SetToolActive(lv_event_t * e, int tool);
+void EjectLane(lv_event_t * e, int lane);
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/wifi_manager.h
+++ b/src/wifi_manager.h
@@ -26,11 +26,7 @@ void saveCredentials(const String& ssid, const String& password, const String& h
 
 extern String targetSSID;
 extern String targetPassword;
-extern String targetSSID;
-extern String targetPassword;
 extern String targetHost;
 extern String apiURL;
-
-
 
 #endif // WIFI_MANAGER_H


### PR DESCRIPTION
- updated polling & evaluation of results to current AFC API version and default config files (leg is no longer used and was replaced by lane) .....(e.g. 'status:' key previously was 'status' - is there now a colon too much?; 'leg' key is replaced by 'lane', etc)
- added evaluation of API return for leg/lane mapping to tool (e.g. lane1 -> T0, lane2 -> T1,...)
- for LaneEject the returned/parsed lane number is used
-_AFC_STATUS is no longer a gcode_macro - polling makes no longer sense / returns no values - function call replaced by a simple return as a quick hack, further changes needed

TJ3D